### PR TITLE
Fix PHP 8 compatibility issues

### DIFF
--- a/class/mainwp-links-checker-db.class.php
+++ b/class/mainwp-links-checker-db.class.php
@@ -505,6 +505,9 @@ $tbl = 'CREATE TABLE `' . $this->table_name( 'linkschecker_links' ) . '` (
         }
 
         public static function num_rows( $result ) {
+                if ( ! self::is_result( $result ) ) {
+                        return 0;
+                }
                 return mysqli_num_rows( $result );
         }
 

--- a/class/mainwp-links-checker.class.php
+++ b/class/mainwp-links-checker.class.php
@@ -1320,7 +1320,7 @@ class MainWP_Links_Checker
 		return $filters;
 	}
 
-	function gen_nav_filters( $websites = array(), $filters) {
+        function gen_nav_filters( $websites, $filters = array() ) {
 
 		$current = isset($filters['filter_id']) ? $filters['filter_id'] : 'all';
 

--- a/mainwp-broken-links-checker-extension.php
+++ b/mainwp-broken-links-checker-extension.php
@@ -3,7 +3,7 @@
 Plugin Name: MainWP Broken Links Checker Extension
 Plugin URI: https://mainwp.com
 Description: MainWP Broken Links Checker Extension allows you to scan and fix broken links on your child sites. Requires the MainWP Dashboard Plugin.
-Version: 4.0
+Version: 4.0.1
 Author: MainWP
 Author URI: https://mainwp.com
 Documentation URI: https://mainwp.com/help/category/mainwp-extensions/broken-links-checker/
@@ -125,19 +125,19 @@ class MainWP_Links_Checker_Extension_Activator
 	protected $childFile;
 	protected $plugin_handle = 'mainwp-broken-links-checker-extension';
 	protected $product_id = 'MainWP Broken Links Checker Extension';
-	protected $software_version = '4.0';
+        protected $software_version = '4.0.1';
 
 
 	public function __construct() {
 
 		$this->childFile = __FILE__;
 		add_filter( 'mainwp-getextensions', array( &$this, 'get_this_extension' ) );
-		$this->mainwpMainActivated = apply_filters( 'mainwp-activated-check', false );
+                $this->mainwpMainActivated = apply_filters( 'mainwp_activated_check', false );
 
 		if ( $this->mainwpMainActivated !== false ) {
 			$this->activate_this_plugin();
 		} else {
-			add_action( 'mainwp-activated', array( &$this, 'activate_this_plugin' ) );
+                        add_action( 'mainwp_activated', array( &$this, 'activate_this_plugin' ) );
 		}
 		add_action( 'admin_init', array( &$this, 'admin_init' ) );
 		add_action( 'admin_notices', array( &$this, 'mainwp_error_notice' ) );
@@ -182,8 +182,8 @@ class MainWP_Links_Checker_Extension_Activator
 
 
 	function activate_this_plugin() {
-		$this->mainwpMainActivated = apply_filters( 'mainwp-activated-check', $this->mainwpMainActivated );
-		$this->childEnabled = apply_filters( 'mainwp-extension-enabled-check', __FILE__ );
+                $this->mainwpMainActivated = apply_filters( 'mainwp_activated_check', $this->mainwpMainActivated );
+                $this->childEnabled = apply_filters( 'mainwp_extension_enabled_check', __FILE__ );
 		$this->childKey = $this->childEnabled['key'];
 		if ( function_exists( 'mainwp_current_user_can' ) && ! mainwp_current_user_can( 'extension', 'mainwp-broken-links-checker-extension' ) ) {
 			return;

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Plugin Name: MainWP Broken Links Checker Extension (Retired)
 Plugin URI: https://mainwp.com
 Description: MainWP Broken Links Checker Extension allows you to scan and fix broken links on your child sites. Requires the MainWP Dashboard Plugin.
-Version: 4.0
+Version: 4.0.1
 Author: MainWP
 Author URI: https://mainwp.com
 


### PR DESCRIPTION
## Summary
- guard num_rows() against non-result values
- update deprecated filter names
- fix optional parameter order in gen_nav_filters()
- bump plugin version to 4.0.1

## Testing
- `php -l mainwp-broken-links-checker-extension.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7629d29c83338f80e233ecfc72cc